### PR TITLE
Checked if history is enabled when selecting a variant

### DIFF
--- a/src/option-selectors-custom.js
+++ b/src/option-selectors-custom.js
@@ -23,7 +23,7 @@ class OptionSelectorsCustom {
     this.hideOriginalSelector();
     this.buildSelectors();
 
-    if (window.Shopify.urlParam('variant')) {
+    if (window.Shopify.urlParam('variant') && this.history) {
       this.selectFromParams();
     } else {
       this.selectInitials();


### PR DESCRIPTION
It's a common pattern now for product cards/boxes/thumbnails to contain variant selectors, & when on a product page, it's important that a variant can be selected by URL (with variant=123123) in the parameter.

if `OptionSelectorsCustom` is called more than once, for multiple product forms, then the first available variant won't be selected if the variant parameter is present. (i.e. on a product page) 

So, if we check for the history flag as well as the param, developers can pass `true|false` to `enableHistory` based on if on a product template, etc.

What do you think?